### PR TITLE
call method from core for local admin authentication

### DIFF
--- a/plugins/ldapAuth.php
+++ b/plugins/ldapAuth.php
@@ -16,7 +16,7 @@
  * of admin users.
  */
 
-require_once dirname(__FILE__).'/../accesscheck.php';
+require_once __DIR__.'/../accesscheck.php';
 
 class ldapAuth extends phplistPlugin {
   public $name = 'LDAP Authentication Plugin';

--- a/plugins/ldapAuth.php
+++ b/plugins/ldapAuth.php
@@ -28,33 +28,9 @@ class ldapAuth extends phplistPlugin {
   public $authProvider = true;
 
   function localValidateLogin($login,$password) {
-    $query
-    = ' select password, disabled, id'
-    . ' from %s'
-    . ' where loginname = ?';
-    $query = sprintf($query, $GLOBALS['tables']['admin']);
-    $req = Sql_Query_Params($query, array($login));
-    $admindata = Sql_Fetch_Assoc($req);
-    $encryptedPass = hash(HASH_ALGO,$password);
-    $passwordDB = $admindata['password'];    
-    #Password encryption verification.
-    if(strlen($passwordDB)<$GLOBALS['hash_length']) { // Passwords are encrypted but the actual is not.
-      #Encrypt the actual DB password before performing the validation below.
-      $encryptedPassDB =  hash(HASH_ALGO,$passwordDB);
-      $query = "update %s set password = '%s' where loginname = ?";
-      $query = sprintf($query, $GLOBALS['tables']['admin'], $encryptedPassDB);
-      $passwordDB = $encryptedPassDB;
-      $req = Sql_Query_Params($query, array($login));
-    } 
-    if ($admindata["disabled"]) {
-      return array(0,s("your account has been disabled"));
-    } elseif (#Password validation.
-      !empty($passwordDB) && $encryptedPass == $passwordDB) {
-      return array($admindata['id'],"OK");
-    } else {
-      return array(0,s("incorrect password"));
-    }
-    return array(0,s("Login failed"));
+    require __DIR__.'/../phpListAdminAuthentication.php';
+    $core_admin_auth = new phpListAdminAuthentication();
+    return $core_admin_auth->validateLogin($login,$password);
   }
 
   function getPassword($email) {

--- a/plugins/ldapAuth.php
+++ b/plugins/ldapAuth.php
@@ -28,7 +28,7 @@ class ldapAuth extends phplistPlugin {
   public $authProvider = true;
 
   function localValidateLogin($login,$password) {
-    require __DIR__.'/../phpListAdminAuthentication.php';
+    require_once __DIR__.'/../phpListAdminAuthentication.php';
     $core_admin_auth = new phpListAdminAuthentication();
     return $core_admin_auth->validateLogin($login,$password);
   }

--- a/plugins/ldapAuth.php
+++ b/plugins/ldapAuth.php
@@ -27,6 +27,9 @@ class ldapAuth extends phplistPlugin {
   public $documentationUrl = 'https://github.com/digital-me/phplist-plugin-ldap';
   public $authProvider = true;
 
+  /**
+   * For users in $ldap_except_users this method provides a fallback to the authentication method from phpList core
+   */
   function localValidateLogin($login,$password) {
     require_once __DIR__.'/../phpListAdminAuthentication.php';
     $core_admin_auth = new phpListAdminAuthentication();


### PR DESCRIPTION
This is for logins from users in $ldap_except_users or when LDAP is turned off in the config. Use the core method instead of code copied from earlier versions of phpList